### PR TITLE
Update PersonalResources.resx with correct spelling of stationery (not stationary)

### DIFF
--- a/INSS.ODS.Bankruptcy.API.Common/Resources/Expenses/PersonalResources.resx
+++ b/INSS.ODS.Bankruptcy.API.Common/Resources/Expenses/PersonalResources.resx
@@ -175,10 +175,10 @@
     <value>Mobile phone</value>
   </data>
   <data name="Expenses_Personal_NewspapersAndMagazines_Error_Negative" xml:space="preserve">
-    <value>The amount you entered for newspapers, magazines, stationary and postage is invalid</value>
+    <value>The amount you entered for newspapers, magazines, stationery and postage is invalid</value>
   </data>
   <data name="Expenses_Personal_NewspapersAndMagazines_Label" xml:space="preserve">
-    <value>Newspapers, magazines, stationary and postage</value>
+    <value>Newspapers, magazines, stationery and postage</value>
   </data>
   <data name="Expenses_Personal_Page_Help1" xml:space="preserve">
     <value>Add your household's personal and leisure expenses.</value>


### PR DESCRIPTION
Updated Stationary to Stationery.  It seems that these resource files are no longer used within the Bankruptcy and Statement of Affairs service, but updated for consistency.